### PR TITLE
fix: prevent Job.get() from auto-creating non-existent jobs

### DIFF
--- a/src/lab/job.py
+++ b/src/lab/job.py
@@ -18,7 +18,6 @@ class Job(BaseLabResource):
         """Abstract method on BaseLabResource"""
         job_id_safe = secure_filename(str(self.id))
         job_dir = os.path.join(dirs.get_jobs_dir(), job_id_safe)
-        os.makedirs(job_dir, exist_ok=True)
         return job_dir
 
     def get_log_path(self):


### PR DESCRIPTION
the Job.get_dir() method was automatically creating job directories which caused Job.get() to never return None for non-existent jobs